### PR TITLE
fix:Make the parse of the replace part in ```go.mod``` more compliant and traceable

### DIFF
--- a/syft/pkg/cataloger/golang/parse_go_mod.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod.go
@@ -77,21 +77,25 @@ func (c *goModCataloger) parseGoModFile(ctx context.Context, resolver file.Resol
 
 		// the old path and new path may be the same, in which case this is a noop,
 		// but if they're different we need to remove the old package.
-		delete(packages, m.Old.Path)
+		var finalPath string
 		if !(strings.HasPrefix(m.New.Path, ".") ||
 			strings.HasPrefix(m.New.Path, "..") || strings.HasPrefix(m.New.Path, "/")) {
-			packages[m.New.Path] = pkg.Package{
-				Name:      m.New.Path,
-				Version:   m.New.Version,
-				Licenses:  pkg.NewLicenseSet(lics...),
-				Locations: file.NewLocationSet(reader.Location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
-				PURL:      packageURL(m.New.Path, m.New.Version),
-				Language:  pkg.Go,
-				Type:      pkg.GoModulePkg,
-				Metadata: pkg.GolangModuleEntry{
-					H1Digest: digests[fmt.Sprintf("%s %s", m.New.Path, m.New.Version)],
-				},
-			}
+			finalPath = m.New.Path
+			delete(packages, m.Old.Path)
+		} else {
+			finalPath = m.Old.Path
+		}
+		packages[finalPath] = pkg.Package{
+			Name:      finalPath,
+			Version:   m.New.Version,
+			Licenses:  pkg.NewLicenseSet(lics...),
+			Locations: file.NewLocationSet(reader.Location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
+			PURL:      packageURL(m.New.Path, m.New.Version),
+			Language:  pkg.Go,
+			Type:      pkg.GoModulePkg,
+			Metadata: pkg.GolangModuleEntry{
+				H1Digest: digests[fmt.Sprintf("%s %s", m.New.Path, m.New.Version)],
+			},
 		}
 
 	}

--- a/syft/pkg/cataloger/golang/parse_go_mod.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod.go
@@ -97,7 +97,6 @@ func (c *goModCataloger) parseGoModFile(ctx context.Context, resolver file.Resol
 				H1Digest: digests[fmt.Sprintf("%s %s", m.New.Path, m.New.Version)],
 			},
 		}
-
 	}
 
 	// remove any packages from the exclude fields

--- a/syft/pkg/cataloger/golang/parse_go_mod.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
 	"sort"
 	"strings"
 
@@ -79,9 +78,8 @@ func (c *goModCataloger) parseGoModFile(ctx context.Context, resolver file.Resol
 		// the old path and new path may be the same, in which case this is a noop,
 		// but if they're different we need to remove the old package.
 		delete(packages, m.Old.Path)
-		u, _ := url.Parse(m.New.Path)
-		switch u.Scheme {
-		case "https", "http":
+		if !(strings.HasPrefix(m.New.Path, ".") ||
+			strings.HasPrefix(m.New.Path, "..") || strings.HasPrefix(m.New.Path, "/")) {
 			packages[m.New.Path] = pkg.Package{
 				Name:      m.New.Path,
 				Version:   m.New.Version,


### PR DESCRIPTION
# Description

When I scan the ```go.mod``` of [aws-sdk-go-v2](https://github.com/aws/aws-sdk-go-v2/blob/main/feature/ec2/imds),there will be some packages with the name pattern like '../../..', but they are only local directory aliases to some remote real link like ```https://github.com/aws/aws-sdk-go-v2```,which is only used as a cache.
Here's the replace part of the ```go.mod```:
```go
replace github.com/aws/aws-sdk-go-v2 => ../../../
```
Here's the reproducible steps:
```bash
cd ~
git clone https://github.com/aws/aws-sdk-go-v2
syft aws-sdk-go-v2/feature/ec2/imds -o spdx-json > sbom.spdx.json
```
And the output is like this
```json
{"artifacts":
[{"id":"567e69993f00fcf8","name":"../../../","version":"UNKNOWN","type":"go-module","foundBy":"go-module-file-cataloger","locations":[{"path":"/go.mod","accessPath":"/go.mod",
"annotations":{"evidence":"primary"}}],"licenses":[],"language":"go","cpes":[{"cpe":"cpe:2.3:a:..:..:*:*:*:*:*:*:*:*","source":"syft-generated"}],"purl":"pkg:golang/../../..","metadataType":"go-module-entry","metadata":{}},
{"id":"ce975785a075b4cf","name":"../../../../../","version":"UNKNOWN","type":"go-module","foundBy":"go-module-file-cataloger","locations":[{"path":"/internal/configtesting/go.mod","accessPath":"/internal/configtesting/go.mod",
"annotations":{"evidence":"primary"}}],"licenses":[],"language":"go","cpes":[{"cpe":"cpe:2.3:a:..:..\\/..\\/..:*:*:*:*:*:*:*:*","source":"syft-generated"}],"purl":"pkg:golang/../../..#../../","metadataType":"go-module-entry","metadata":{}},
{"id":"d30c6d6af8d7b916","name":"../../../../../config/","version":"UNKNOWN","type":"go-module","foundBy":"go-module-file-cataloger","locations":[{"path":"/internal/configtesting/go.mod","accessPath":"/internal/configtesting/go.mod",
"annotations":{"evidence":"primary"}}],"licenses":[],"language":"go","cpes":[{"cpe":"cpe:2.3:a:..:..\\/..\\/..\\/config:*:*:*:*:*:*:*:*","source":"syft-generated"}],"purl":"pkg:golang/../../..#../../config/","metadataType":"go-module-entry","metadata":{}},
{"id":"b0c3fd64cef7d2a2","name":"../../../../../credentials/","version":"UNKNOWN","type":"go-module","foundBy":"go-module-file-cataloger","locations":[{"path":"/internal/configtesting/go.mod","accessPath":"/internal/configtesting/go.mod",
"annotations":{"evidence":"primary"}}],"licenses":[],"language":"go","cpes":[{"cpe":"cpe:2.3:a:..:..\\/..\\/..\\/credentials:*:*:*:*:*:*:*:*","source":"syft
```
Fixing this will enhance the traceability of SBOM.

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
